### PR TITLE
Fixed win7 will crash use wasapi

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -689,7 +689,8 @@ SDL_RunAudio(void *devicep)
             /* if this fails...oh well. We'll play silence here. */
             SDL_AudioStreamPut(device->stream, data, data_len);
 
-            while (SDL_AudioStreamAvailable(device->stream) >= ((int) device->spec.size)) {
+            while (SDL_AudioStreamAvailable(device->stream) >= ((int) device->spec.size) &&
+                !SDL_AtomicGet(&device->shutdown)) {
                 int got;
                 data = SDL_AtomicGet(&device->enabled) ? current_audio.impl.GetDeviceBuf(device) : NULL;
                 got = SDL_AudioStreamGet(device->stream, data ? data : device->work_buffer, device->spec.size);

--- a/src/audio/wasapi/SDL_wasapi.c
+++ b/src/audio/wasapi/SDL_wasapi.c
@@ -413,6 +413,7 @@ RecoverWasapiDevice(_THIS)
         this->hidden->default_device_generation = SDL_AtomicGet(this->iscapture ?  &default_capture_generation : &default_playback_generation);
         ret = IMMDeviceEnumerator_GetDefaultAudioEndpoint(enumerator, dataflow, SDL_WASAPI_role, &device);
         if (FAILED(ret)) {
+            SDL_AtomicSet(&this->shutdown, 1);
             return SDL_FALSE;  /* can't find a new default device! */
         }
     } else {


### PR DESCRIPTION
I've test two windows 7. both are 6.1.7601 Service pack 1 Buid 7601. when I unplug my headset will cause null pointer of  SDL_AudioDevice.hidden.render