### PR TITLE
Add Zhaoxin processor support

### DIFF
--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -705,7 +705,7 @@ SDL_GetCPUCacheLineSize(void)
     const char *cpuType = SDL_GetCPUType();
     int a, b, c, d;
     (void) a; (void) b; (void) c; (void) d;
-    if (SDL_strcmp(cpuType, "GenuineIntel") == 0) {
+    if (SDL_strcmp(cpuType, "GenuineIntel") == 0 || SDL_strcmp(cpuType, "CentaurHauls") == 0 || SDL_strcmp(cpuType, "  ShangHai  ") == 0) {
         cpuid(0x00000001, a, b, c, d);
         return (((b >> 8) & 0xff) * 8);
     } else if (SDL_strcmp(cpuType, "AuthenticAMD") == 0 || SDL_strcmp(cpuType, "HygonGenuine") == 0) {


### PR DESCRIPTION
Add Zhaoxin processor support

CPU Vendor ID "Shanghai" and "CentaurHauls" belongs to Zhaoxin.  

Background:
Shanghai Zhaoxin Semiconductor Co., Ltd ("Zhaoxin") , established in 2013,
headquartered in Zhangjiang, Shanghai, China. Zhaoxin aims at providing
general-purpose x86 processors.

Related Zhaoxin Linux Kernel patch can be found at
https://lore.kernel.org/lkml/01042674b2f741b2aed1f797359bdffb@zhaoxin.com

Best regards.